### PR TITLE
AsciiBorderFormatter

### DIFF
--- a/src/main/kotlin/formatter/AsciiBorderFormatter.kt
+++ b/src/main/kotlin/formatter/AsciiBorderFormatter.kt
@@ -1,0 +1,21 @@
+package formatter
+
+class AsciiBorderFormatter : BorderFormatter {
+
+    override fun format(rows: Sequence<List<String>>): String {
+        val horizontalSeparator = StringBuilder("+") //+----+----+------+ and etc.
+
+        rows.first().forEach { elem ->
+            horizontalSeparator.apply {
+                append("-".repeat(elem.length))
+                append('+')
+
+            }
+        }
+
+        return rows.map {
+                row -> row.joinToString("|", "|", "|")
+        }.joinToString("\n$horizontalSeparator\n", "$horizontalSeparator\n", "\n$horizontalSeparator")
+    }
+
+}

--- a/src/main/kotlin/formatter/EmptyBorderFormatter.kt
+++ b/src/main/kotlin/formatter/EmptyBorderFormatter.kt
@@ -3,9 +3,7 @@ package formatter
 class EmptyBorderFormatter : BorderFormatter {
 
     override fun format(rows: Sequence<List<String>>): String {
-        /*val width = rows.map { row -> row.map { elem -> elem.length }.sum() }.max()
-        val res = StringBuilder()*/
-        return rows.map { row -> row.joinToString("") }.joinToString("\n")
+        return rows.map { row -> row.joinToString("\t") }.joinToString("\n")
     }
 
 }

--- a/src/main/kotlin/formatter/TableFormatter.kt
+++ b/src/main/kotlin/formatter/TableFormatter.kt
@@ -3,16 +3,16 @@ package formatter
 class TableFormatter(private val borderFormatter: BorderFormatter) {
 
     companion object {
-        fun create(): TableFormatter {
-            return TableFormatter(EmptyBorderFormatter())
+        fun create(borderFormatter: BorderFormatter = EmptyBorderFormatter()): TableFormatter {
+            return TableFormatter(borderFormatter)
         }
     }
 
-    private val rows = mutableListOf<List<String>>()
+    private val rows = mutableListOf<MutableList<String>>()
 
 
     fun<T> addRow(vararg values: T) {
-        rows.add(values.asSequence().map { it.toString() }.toList())
+        rows.add(values.asSequence().map { it.toString() }.toMutableList())
     }
 
     fun removeAt(index: Int) {
@@ -31,9 +31,16 @@ class TableFormatter(private val borderFormatter: BorderFormatter) {
             }.max() ?: 0
         }
 
-        val res: Sequence<List<String>> = rows.asSequence().map {
+        val sameSizeRows = rows.map { row ->
+            while (row.size < columnsCount) {
+                row.add("")
+            }
+            row
+        }
+
+        val res: Sequence<List<String>> = sameSizeRows.asSequence().map {
             row -> row.mapIndexed {
-                index, elem -> elem + " ".repeat(lengths[index] - elem.length) + "\t"
+                index, elem -> elem + " ".repeat(lengths[index] - elem.length)
             }
         }
 

--- a/src/test/kotlin/formatter/TableFormatterTest.kt
+++ b/src/test/kotlin/formatter/TableFormatterTest.kt
@@ -8,21 +8,46 @@ import kotlin.test.assertEquals
 
 class TableFormatterTest {
 
-    @Test
-    fun borderlessTest() {
-
-        val borderLessResult =
-        "Test   \ttest\ttestet\t\n" +
-                "ter    \tte  \t\n" +
-                "123.123\t12.0\ttest  \t123\t"
-
-        val tableFormatter = TableFormatter.create()
+    private fun formatterTest(tableFormatter: TableFormatter, expected: String) {
         tableFormatter.addRow("Test", "test", "testet")
         tableFormatter.addRow("ter", "te")
         tableFormatter.addRow(123, 13, 123)
         tableFormatter.addRow(123.123, 12.0, "test", 123)
         tableFormatter.removeAt(2)
+        assertEquals(expected, tableFormatter.format())
+    }
 
-        assertEquals(tableFormatter.format(), borderLessResult)
+    @Test fun borderlessTest() {
+        val expected =
+        "Test   \ttest\ttestet\t\n" +
+                "ter    \tte  \t\n" +
+                "123.123\t12.0\ttest  \t123\t"
+
+        val tableFormatter = TableFormatter.create()
+        formatterTest(tableFormatter, expected)
+    }
+
+    @Test fun emptyBorderlessTest() {
+        val tableFormatter = TableFormatter.create()
+        assertEquals(tableFormatter.format(), "")
+    }
+
+    @Test fun asciiBorderTest() {
+        val expected =
+                "+-------+----+------+---+\n" +
+                "|Test   |test|testet|   |\n" +
+                "+-------+----+------+---+\n" +
+                "|ter    |te  |      |   |\n" +
+                "+-------+----+------+---+\n" +
+                "|123.123|12.0|test  |123|\n" +
+                "+-------+----+------+---+"
+
+        val tableFormatter = TableFormatter.create(AsciiBorderFormatter())
+        formatterTest(tableFormatter, expected)
+    }
+
+    @Test fun emptyAsciiBorderTest() {
+        val tableFormatter = TableFormatter.create(AsciiBorderFormatter())
+        assertEquals(tableFormatter.format(), "")
     }
 }


### PR DESCRIPTION
1. Refactored TableFormatter and EmptyBorderFormatter.  Now tabulation is part of EmptyBorderFormatter.
2. Added AsciiBorderFormatter. It make table without '\t', but with with [-, |, +].
3. Remake tests and add new for AsciiBorderFormatter